### PR TITLE
build: Generate enclave_t.c before building the example enclave.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,6 +94,7 @@ example_application_LDADD = src/libtcti-sgx-mgr.la $(SGX_URTS_LIBS)
 example_application_SOURCES = example/application.c example/enclave_ocalls.c
 nodist_example_application_SOURCES = example/enclave_u.c
 example/application.$(OBJEXT): example/enclave_u.c
+example/enclave.$(OBJECT): example/enclave_t.c
 
 example/.deps:
 	mkdir -p $@


### PR DESCRIPTION
This fixes a race condition between building the application and the
enclave.

Signed-off-by: Philip Tricca <Philip Tricca philip.b.tricca@intel.com>