### PR TITLE
build: Change cmocka requirement from version 1.1 to 1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AS_IF(
     [
     PKG_CHECK_MODULES(
         [CMOCKA],
-        [cmocka >= 1.1],
+        [cmocka >= 1.0],
         [],
         [AC_MSG_ERROR([cmocka version must be > 1.1])])
     ])


### PR DESCRIPTION
The API changed in 1.0 not 1.1. We need at least 1.0 though later will
work as well.

Signed-off-by: Philip Tricca <Philip Tricca philip.b.tricca@intel.com>