### PR TITLE
build: Move addition of -fPIC from automake to autoconf.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 VPATH = $(srcdir) $(builddir)
 ACLOCAL_AMFLAGS = -I m4
-AM_CFLAGS = -I$(SGX_INCLUDE_DIR) -I$(srcdir)/src -fPIC
+AM_CFLAGS = $(EXTRA_CFLAGS) -I$(SGX_INCLUDE_DIR) -I$(srcdir)/src
 AM_CXXFLAGS = $(AM_CFLAGS) $(EXTRA_CXXFLAGS)
 ENCLAVE_CFLAGS += -I$(SGX_INCLUDE_DIR)/tlibc
 CLEANFILES = \

--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,7 @@ AC_DEFUN(
     ]
 )
 
+ADD_COMPILER_FLAG([-fPIC],[EXTRA_CFLAGS])
 # CFLAGS used when building code that runs in the enclave
 ADD_COMPILER_FLAG([-fvisibility=hidden],[ENCLAVE_CFLAGS])
 ADD_COMPILER_FLAG([-fpie],[ENCLAVE_CFLAGS])


### PR DESCRIPTION
This should be checked against the compiler to be sure it's supported
first. Also adding flags like this @ build time is bad. Should always be
done at configure time.

Signed-off-by: Philip Tricca <Philip Tricca philip.b.tricca@intel.com>