### PR TITLE
mgr: Fix bad function type in receive_ocall.

### DIFF
--- a/src/tcti-sgx-mgr.cpp
+++ b/src/tcti-sgx-mgr.cpp
@@ -212,7 +212,7 @@ TSS2_RC
 tcti_sgx_receive_ocall (uint64_t id,
                         size_t size,
                         uint8_t *response,
-                        uint32_t timeout)
+                        int32_t timeout)
 {
     TctiSgxMgr& mgr = TctiSgxMgr::get_instance (NULL, NULL);
     TctiSgxSession *session;

--- a/src/tcti-sgx-mgr_priv.h
+++ b/src/tcti-sgx-mgr_priv.h
@@ -67,7 +67,7 @@ TSS2_RC tcti_sgx_transmit_ocall (uint64_t id,
 TSS2_RC tcti_sgx_receive_ocall (uint64_t id,
                                 size_t size,
                                 uint8_t *response,
-                                uint32_t timeout);
+                                int32_t timeout);
 void tcti_sgx_finalize_ocall (uint64_t id);
 TSS2_RC tcti_sgx_cancel_ocall (uint64_t id);
 TSS2_RC tcti_sgx_get_poll_handles_ocall (uint64_t id,

--- a/src/tcti-sgx.c
+++ b/src/tcti-sgx.c
@@ -25,7 +25,7 @@ sgx_status_t tcti_sgx_receive_ocall (TSS2_RC *rc,
                                      uint64_t session_id,
                                      size_t size,
                                      uint8_t *response,
-                                     uint32_t timeout);
+                                     int32_t timeout);
 sgx_status_t tcti_sgx_finalize_ocall (uint64_t session_id);
 sgx_status_t tcti_sgx_cancel_ocall (TSS2_RC *rc,
                                     uint64_t session_id);

--- a/src/tss2_tcti_sgx.edl
+++ b/src/tss2_tcti_sgx.edl
@@ -13,7 +13,7 @@
         TSS2_RC tcti_sgx_receive_ocall (uint64_t session_id,
                                         size_t size,
                                         [in, out, size=size] uint8_t *response,
-                                        uint32_t timeout);
+                                        int32_t timeout);
         void tcti_sgx_finalize_ocall (uint64_t session_id);
         TSS2_RC tcti_sgx_cancel_ocall (uint64_t session_id);
         TSS2_RC tcti_sgx_set_locality_ocall (uint64_t session_id,


### PR DESCRIPTION
The timeout must be a signed value since -1 indicates a blocking call.

Signed-off-by: Philip Tricca <Philip Tricca philip.b.tricca@intel.com>