### PR TITLE
build: Add compiler hardening flags.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,12 +139,15 @@ ADD_COMPILER_FLAG([-fPIC])
 ADD_COMPILER_FLAG([-Wall])
 ADD_COMPILER_FLAG([-Werror])
 ADD_COMPILER_FLAG([-Wextra])
+ADD_COMPILER_FLAG([-fstack-protector])
+ADD_COMPILER_FLAG([-fstack-protector-strong])
+ADD_COMPILER_FLAG([-D_FORTIFY_SOURCE=2])
+ADD_COMPILER_FLAG([-Wformat -Wformat-security])
 ADD_CXX_COMPILER_FLAG([-std=c++11])
 AS_IF([test "$CODE_COVERAGE_ENABLED" = "no"],
       [ADD_COMPILER_FLAG([-fvisibility=hidden])])
 # CFLAGS used when building code that runs in the enclave
 ADD_COMPILER_FLAG([-fpie],[ENCLAVE_CFLAGS])
-ADD_COMPILER_FLAG([-fstack-protector],[ENCLAVE_CFLAGS])
 
 AC_DEFUN(
     [ADD_LINK_FLAG],


### PR DESCRIPTION
Based on recommendations from:
https://developers.redhat.com/blog/2018/03/21/compiler-and-linker-flags-gcc/
https://wiki.debian.org/Hardening
https://security.stackexchange.com/questions/24444/what-is-the-most-hardened-set-of-options-for-gcc-compiling-c-c

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>